### PR TITLE
fix: seeker does not overlap track text

### DIFF
--- a/client/components/Player/styles.ts
+++ b/client/components/Player/styles.ts
@@ -41,13 +41,15 @@ export const styles = StyleSheet.create({
   },
   playbackSlider: {
     alignSelf: "stretch",
-    marginBottom: 8,
+    marginBottom: -6,
+    marginTop: 12,
   },
   trackInfoRow: {
     alignItems: "center",
     flex: 1,
     flexDirection: "row",
     minHeight: FONT_SIZE,
+    position: "absolute",
     textAlign: "center",
   },
   text: {


### PR DESCRIPTION
![Simulator Screen Shot - iPhone 13 - 2022-10-30 at 13 41 12](https://user-images.githubusercontent.com/60944077/198895907-de1191c0-a1e4-4c7f-9bf6-20acf774398b.png)

This closes #36.