### PR TITLE
fix: track duration text overflow in player

### DIFF
--- a/client/components/Player/index.tsx
+++ b/client/components/Player/index.tsx
@@ -238,7 +238,7 @@ export default function Player(): JSX.Element {
           },
         ]}
       >
-        <View style={styles.trackInfoRow}>
+        <View style={[styles.trackInfoRow, { bottom: bottom + 30 }]}>
           <Text style={[styles.text, styles.buffering]}>
             {isBuffering ? BUFFERING_STRING : ""}
           </Text>

--- a/client/components/Player/index.tsx
+++ b/client/components/Player/index.tsx
@@ -238,7 +238,14 @@ export default function Player(): JSX.Element {
           },
         ]}
       >
-        <View style={[styles.trackInfoRow, { bottom: bottom + 30 }]}>
+        <View
+          style={[
+            styles.trackInfoRow,
+            {
+              bottom: BOTTOM_NAVIGATION_HEIGHT - 50,
+            },
+          ]}
+        >
           <Text style={[styles.text, styles.buffering]}>
             {isBuffering ? BUFFERING_STRING : ""}
           </Text>

--- a/client/components/Player/styles.ts
+++ b/client/components/Player/styles.ts
@@ -50,7 +50,6 @@ export const styles = StyleSheet.create({
     flexDirection: "row",
     minHeight: FONT_SIZE,
     position: "absolute",
-    bottom: FONT_SIZE * 2,
     textAlign: "center",
   },
   text: {

--- a/client/components/Player/styles.ts
+++ b/client/components/Player/styles.ts
@@ -50,6 +50,7 @@ export const styles = StyleSheet.create({
     flexDirection: "row",
     minHeight: FONT_SIZE,
     position: "absolute",
+    bottom: FONT_SIZE * 2,
     textAlign: "center",
   },
   text: {
@@ -61,8 +62,8 @@ export const styles = StyleSheet.create({
     textAlign: "left",
   },
   timestamp: {
-    paddingLeft: 20,
-    textAlign: "right",
+    position: "absolute",
+    right: 16,
   },
   buttonsContainerBase: {
     alignItems: "center",


### PR DESCRIPTION
This hopefully closes #36.

Need to test iOS still and to make sure it doesn't break other screen sizes though.

![image](https://user-images.githubusercontent.com/60944077/198920438-9c80442d-bef1-471f-bd06-aa55fb79f6f8.png)
